### PR TITLE
Fixed "Allow Null" for fields 

### DIFF
--- a/lib/DBMan.php
+++ b/lib/DBMan.php
@@ -129,7 +129,7 @@ class DBMan {
 			return $rules;
 		}
 
-		if ($field->notnull == 'Yes') {
+		if ($field->notnull == 'No') {
 			$rules['not empty'] = 1;
 		}
 		if (in_array ($field->type, array ('int', 'integer', 'float'))) {


### PR DESCRIPTION
Applied fix to allow a field to be empty if the Database table specified that field as "Allow NULL"

As it was, the DB Manager would not let you save if the field was empty and was allowed to be null.
